### PR TITLE
Enable TOR activation and honor neutral offset

### DIFF
--- a/IOMap.cpp
+++ b/IOMap.cpp
@@ -107,10 +107,8 @@ Axes8 mapADSAll(const ADSRaw& r){
   a.LX= mapADSWithCal(r.LX,cal[3]); a.LY= mapADSWithCal(r.LY,cal[4]); a.LZ= mapADSWithCal(r.LZ,cal[5]);
   a.R1= mapADSWithCal(r.R1,cal[6]); a.R2= mapADSWithCal(r.R2,cal[7]);
 
-  int delta = neutralOffset - 512;
   int *v = (int*)&a;
   for(int i=0;i<8;i++){
-    v[i] += delta;
     if(v[i] < mapMin) v[i] = mapMin;
     if(v[i] > mapMax) v[i] = mapMax;
   }
@@ -150,23 +148,23 @@ void applyAxisToPair(uint8_t pwmCh, int val){
   const float DUTY_MAX = 0.75f;
 
   float duty = DUTY_MID;
-  bool dirAbove = false; // false: below neutral; true: above neutral
+  bool active = false; // true when axis is outside neutral window
 
   if (val < joyNeutralMin){
     duty = mapf((float)val, (float)mapMin, (float)joyNeutralMin, DUTY_MIN, DUTY_MID);
-    dirAbove = false;
+    active = true;
   } else if (val > joyNeutralMax){
     duty = mapf((float)val, (float)joyNeutralMax, (float)mapMax, DUTY_MID, DUTY_MAX);
-    dirAbove = true;
+    active = true;
   } else {
     duty = DUTY_MID;
-    dirAbove = false;
+    active = false;
   }
 
   if (pwmCh < 8){
     setPWMpercent(pwmCh, duty);
     uint8_t torCh = PWM_TO_TOR[pwmCh];
-    setTOR(torCh, dirAbove);
+    setTOR(torCh, active);
   }
 }
 void neutralizeAllOutputs(){ for(uint8_t i=0;i<8;++i) setPWMpercent(i,0.5f); for(uint8_t i=8;i<16;++i) setTOR(i,false); }


### PR DESCRIPTION
## Summary
- Activate PCA9685 TOR outputs whenever joystick axis leaves the neutral window in either direction
- Apply neutral offset solely through window and range limits so wired joystick voltages shift when the web UI offset changes

## Testing
- `g++ -std=c++17 -Wall -Wextra -c IOMap.cpp` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a83d150cf88327bec093a4dd0be24f